### PR TITLE
Add GitHub Actions CI/CD workflow for automatic deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - run: pnpm install
+
+      - run: pnpm build
+
+      - name: Write CNAME
+        run: echo 'note.wiki' > docs/CNAME
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22.22.0'
           cache: pnpm
 
       - run: pnpm install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 pnpm dev       # Start VitePress dev server (serves src/)
 pnpm build     # Build static site to docs/
-pnpm deploy    # Build + commit + push (auto deploy via deploy.sh)
 ```
+
+Deployment is automated via GitHub Actions — push to `master` triggers a build and deploy to GitHub Pages automatically.
 
 Prettier runs automatically on `src/**` files at pre-commit via husky + lint-staged.
 
@@ -21,8 +22,9 @@ This is a [VitePress](https://vitepress.dev/) static site that publishes to GitH
 - **`src/`** — Markdown content source files. All new notes go here.
 - **`src/frontend/`** — The main content section (css, js, es, vue, react, ssr, browser, network, algorithm, lib).
 - **`src/.vitepress/config.mts`** — VitePress config: sets `outDir` to `../docs`, nav, sidebar, GA, edit links.
-- **`docs/`** — Built output (committed to master, served via GitHub Pages). Do not edit manually.
-- **`deploy.sh`** — Builds, writes `docs/CNAME`, then commits and pushes everything to master.
+- **`docs/`** — Built output served via GitHub Pages. Do not edit manually.
+- **`.github/workflows/deploy.yml`** — GitHub Actions workflow: builds on push to `master`, deploys via `actions/deploy-pages`.
+- **`deploy.sh`** — Legacy manual deploy script (no longer needed).
 - **`.npmrc`** — Sets `shamefully-hoist=true` (required for VitePress under pnpm).
 
 ## Adding Content


### PR DESCRIPTION
Replace manual deploy.sh with a GitHub Actions workflow that triggers
on push to master, builds the VitePress site, and deploys to GitHub Pages
via actions/deploy-pages.

https://claude.ai/code/session_01CgGi2AHXj4ypuqDF8gAvcn